### PR TITLE
Create pages to View, Edit, Clone, and Create a recipe

### DIFF
--- a/SQL_Scripts/TheTofuWarriorsDB_Seed.sql
+++ b/SQL_Scripts/TheTofuWarriorsDB_Seed.sql
@@ -20,7 +20,8 @@ VALUES ('tsp', 'Teaspoon')
 	,('oz', 'Ounce')
 	,('fl oz', 'Fluid Ounce')
 	,('lb', 'Pound')
-	,('kg', 'Kilogram');
+	,('kg', 'Kilogram')
+	,('cup', 'One Cup');
 
 INSERT INTO App.Ingredient ([Name], [Description])
 VALUES ('Chicken breast', 'Skinned chicken breast'),

--- a/SQL_Scripts/UsersAndRecipes_Seed.sql
+++ b/SQL_Scripts/UsersAndRecipes_Seed.sql
@@ -22,6 +22,18 @@ VALUES
 (5, 'Hot dogs', 'Take a weiner and put it in the microwave for 5 mins', DATEFROMPARTS(2021, 9, 15)),
 (1, 'Chicken', 'Just boil it until it is cooked', GETDATE());
 
+INSERT INTO App.RecipeIngredient (RecipeId, IngredientId, Quantity, MeasureUnitId)
+VALUES
+(1, 1, 1, 14),
+(2, 1, 2, 14),
+(2, 5, 1, 16),
+(3, 5, 1, 16),
+(4, 4, 2, 16),
+(5, 7, 5, 12),
+(6, 6, 2, 8),
+(7, 1, 18, 12),
+(8, 1, 2, 14);
+
 
 -- TagType isn't defined yet, but we could start with something like
 --			1 = Allergy/Diet info,

--- a/TheTofuWarriors/TofuWarrior.BusinessLogic/Interfaces/IIngredientRepository.cs
+++ b/TheTofuWarriors/TofuWarrior.BusinessLogic/Interfaces/IIngredientRepository.cs
@@ -3,10 +3,18 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using TheTofuWarrior.Model.ViewModels;
+using TofuWarrior.Model.ViewModels;
 
 namespace TofuWarrior.BusinessLogic.Interfaces
 {
     public interface IIngredientRepository
     {
+		Task<List<ViewModelIngredient>> GetAllIngredients();
+        Task<ViewModelIngredient> AddIngredient(ViewModelIngredient data);
+        Task<ViewModelIngredient> GetIngredientById(int ingredientId);
+        Task<ViewModelRecipe> AddIngredientToRecipe(ViewModelRecipeIngredient data);
+        Task<ViewModelRecipe> RemoveIngredientFromRecipe(ViewModelRecipeIngredient data);
+        Task<ViewModelRecipe> UpdateRecipeIngredient(ViewModelRecipeIngredient data);
     }
 }

--- a/TheTofuWarriors/TofuWarrior.BusinessLogic/Interfaces/IRepository.cs
+++ b/TheTofuWarriors/TofuWarrior.BusinessLogic/Interfaces/IRepository.cs
@@ -15,5 +15,6 @@ namespace TofuWarrior.BusinessLogic.Interfaces
         Task<Recipe> DeleteItemAsync(ViewModelRecipe item);
         Task<Recipe> CreateItemAsync(ViewModelRecipe item);
 		Task<List<ViewModelRecipe>> SearchRecipes(List<string> ingredientNames, List<ViewModelTag> tags);
+		Task<ViewModelRecipe> SaveUserRecipe(ViewModelRecipe recipe, ViewModelUser user);
     }
 }

--- a/TheTofuWarriors/TofuWarrior.BusinessLogic/Repositories/ApiRecipeMapper.cs
+++ b/TheTofuWarriors/TofuWarrior.BusinessLogic/Repositories/ApiRecipeMapper.cs
@@ -25,8 +25,12 @@ namespace TofuWarrior.BusinessLogic.Repositories
 				IngredientName = ingredient.food,
 				IngredientDescription = ingredient.text,
 				MeasureUnitId = 0,
-				MeasureUnit = ingredient.measure,
-				MeasureDescription = ingredient.measure
+				MeasureUnit = new ViewModelMeasurement()
+				{
+					MeasureUnitId = 0,
+					Description = ingredient.measure,
+					Unit = ingredient.measure
+				}
 			};
 		}
 		public static ViewModelRecipe ConvertToModel(ApiModel.Recipe apiModel)

--- a/TheTofuWarriors/TofuWarrior.BusinessLogic/Repositories/IngredientRepository.cs
+++ b/TheTofuWarriors/TofuWarrior.BusinessLogic/Repositories/IngredientRepository.cs
@@ -30,8 +30,8 @@ namespace TofuWarrior.BusinessLogic.Repositories
         {
             var ingredient = new Ingredient()
             {
-                Name = data.Name,
-                Description = data.Description
+                Name = data.IngredientName,
+                Description = data.IngredientDescription
             };
             _db.Ingredients.Add(ingredient);
             await _db.SaveChangesAsync();

--- a/TheTofuWarriors/TofuWarrior.BusinessLogic/Repositories/Mapper.cs
+++ b/TheTofuWarriors/TofuWarrior.BusinessLogic/Repositories/Mapper.cs
@@ -95,8 +95,7 @@ namespace TofuWarrior.BusinessLogic.Repositories
 				IngredientName = recipeIngredient.Ingredient?.Name,
 				IngredientDescription = recipeIngredient.Ingredient?.Description,
 				MeasureUnitId = recipeIngredient.MeasureUnitId,
-				MeasureUnit = recipeIngredient.MeasureUnit?.Unit,
-				MeasureDescription = recipeIngredient.MeasureUnit?.Description
+				MeasureUnit = ConvertToModel(recipeIngredient.MeasureUnit)
 			};
 			return result;
 		}
@@ -107,9 +106,9 @@ namespace TofuWarrior.BusinessLogic.Repositories
 
 			var model = new ViewModelIngredient()
 			{
-				Name = ingredient.Name,
+				IngredientName = ingredient.Name,
 				IngredientId = ingredient.IngredientId,
-				Description = ingredient.Description
+				IngredientDescription = ingredient.Description
 			};
 			return model;
 		}

--- a/TheTofuWarriors/TofuWarrior.BusinessLogic/Repositories/Mapper.cs
+++ b/TheTofuWarriors/TofuWarrior.BusinessLogic/Repositories/Mapper.cs
@@ -75,6 +75,7 @@ namespace TofuWarrior.BusinessLogic.Repositories
 			recipe.RecipeId = r.RecipeId;
 			recipe.Instructions = r.Instructions;
 			recipe.CreatorUserId = r.CreatorUserId;
+			recipe.Creator = ConvertToModel(r.CreatorUser);
 			recipe.CreationTime = r.CreationTime;
 			recipe.Name = r.Name;
 			recipe.Ingredients = (from ri in r.RecipeIngredients select ConvertToModel(ri)).ToList();

--- a/TheTofuWarriors/TofuWarrior.BusinessLogic/Repositories/RecipeRepo.cs
+++ b/TheTofuWarriors/TofuWarrior.BusinessLogic/Repositories/RecipeRepo.cs
@@ -46,19 +46,28 @@ namespace TofuWarrior.BusinessLogic.Repositories
         public async Task<List<ViewModelRecipe>> GetAllItemAsync()
         {
             
-            List<Recipe> recipes = await _context.Recipes.ToListAsync();
+            List<Recipe> recipes = await _context.Recipes
+				.Include(r => r.CreatorUser)
+				.Include(r => r.RecipeIngredients)
+				.ThenInclude(ri => ri.Ingredient)
+				.ToListAsync();
             List<ViewModelRecipe> views = new List<ViewModelRecipe>();
             foreach(Recipe r in recipes)
             {
-                views.Add(Mapper.RecipeToViewModelRecipe(r));
+				_logger.LogInformation("Recipe ingredient count: {0}", r.RecipeIngredients.Count);
+                views.Add(Mapper.ConvertToModel(r));
             }
             return views;
         }
 
         public async Task<ViewModelRecipe> GetItemsByIdAsync(int id)
         {
-            Recipe result = await _context.Recipes.FirstOrDefaultAsync(recipe => recipe.RecipeId == id) ;
-            ViewModelRecipe views = Mapper.RecipeToViewModelRecipe(result);
+            Recipe result = await _context.Recipes
+				.Include(r => r.CreatorUser)
+				.Include(r => r.RecipeIngredients)
+				.ThenInclude(ri => ri.Ingredient)
+				.FirstOrDefaultAsync(recipe => recipe.RecipeId == id) ;
+            ViewModelRecipe views = Mapper.ConvertToModel(result);
             return views;
         }
 

--- a/TheTofuWarriors/TofuWarrior.BusinessLogic/Repositories/RecipeRepo.cs
+++ b/TheTofuWarriors/TofuWarrior.BusinessLogic/Repositories/RecipeRepo.cs
@@ -27,6 +27,11 @@ namespace TofuWarrior.BusinessLogic.Repositories
 			_adamamRecipeApi = recipeApi;
         }
 
+		/// <summary>
+		/// add recipe to database (only affects recipe table)
+		/// </summary>
+		/// <param name="item"></param>
+		/// <returns></returns>
 		public async Task<Recipe> CreateItemAsync(ViewModelRecipe item)
         {
             Recipe r = Mapper.ViewModelRecipeToRecipe(item);
@@ -34,6 +39,78 @@ namespace TofuWarrior.BusinessLogic.Repositories
             await _context.SaveChangesAsync();
             return r;
         }
+
+		private async Task<List<RecipeIngredient>> CreateRecipeIngredients(ViewModelRecipe recipe)
+		{
+			List<RecipeIngredient> result = new();
+			foreach (var ingredient in recipe.Ingredients)
+			{
+				Ingredient dbIngredient = await (from i in _context.Ingredients where i.IngredientId == ingredient.IngredientId select i).FirstAsync();
+				MeasureUnit dbMeasure = await (from m in _context.MeasureUnits where m.MeasureUnitId == ingredient.MeasureUnitId select m).FirstAsync();
+				result.Add(new RecipeIngredient()
+				{
+					Quantity = ingredient.Quantity,
+					Ingredient = dbIngredient,
+					IngredientId = dbIngredient.IngredientId,
+					MeasureUnit = dbMeasure,
+					MeasureUnitId = dbMeasure.MeasureUnitId,
+				});
+			}
+			return result;
+		}
+
+		/// <summary>
+		/// add/update recipe in database (updates all linking tables)
+		/// </summary>
+		/// <param name="item"></param>
+		/// <returns></returns>
+		public async Task<ViewModelRecipe> SaveUserRecipe(ViewModelRecipe recipe, ViewModelUser user)
+		{
+			var dbUser = await (from u in _context.Users where u.UserId == user.UserId select u).FirstAsync();
+			Recipe newRecipe;
+			if (recipe.RecipeId == 0)
+			{
+				newRecipe = new Recipe();
+			} else
+			{
+				newRecipe = await (from r in _context.Recipes where r.RecipeId == recipe.RecipeId select r)
+					.Include(r => r.RecipeIngredients)
+					.Include(r => r.RecipeTags)
+					.FirstAsync();
+			}
+			newRecipe.CreatorUserId = recipe.CreatorUserId;
+			newRecipe.Instructions = recipe.Instructions;
+			newRecipe.Name = recipe.Name;
+			if (recipe.RecipeId != 0)
+			{
+				_context.RecipeIngredients.RemoveRange(newRecipe.RecipeIngredients);
+				await _context.SaveChangesAsync();
+				newRecipe.RecipeIngredients.Clear();
+			}
+			newRecipe.RecipeIngredients = await CreateRecipeIngredients(recipe);
+				//TODO: make tags work
+			newRecipe.RecipeTags = new List<RecipeTag>();
+			newRecipe.CreatorUser = dbUser;
+			if (recipe.RecipeId == 0)
+			{
+				_context.Recipes.Add(newRecipe);
+			}
+			if (recipe.RecipeId != 0)
+			{
+				UserRecipe newUR = new()
+				{
+					User = dbUser,
+					UserId = dbUser.UserId,
+					// TODO: Fix apikey type
+					//ApiRecipeKey = recipe.ApiKey,
+					Recipe = newRecipe,
+				};
+				_context.UserRecipes.Add(newUR);
+			}
+			_context.RecipeIngredients.AddRange(newRecipe.RecipeIngredients);
+			await _context.SaveChangesAsync();
+			return Mapper.ConvertToModel(newRecipe);
+		}
 
         public async Task<Recipe> DeleteItemAsync(ViewModelRecipe item)
         {
@@ -43,14 +120,20 @@ namespace TofuWarrior.BusinessLogic.Repositories
             return r;
         }
 
-        public async Task<List<ViewModelRecipe>> GetAllItemAsync()
-        {
-            
-            List<Recipe> recipes = await _context.Recipes
+		private IQueryable<Recipe> GetRecipesBaseQuery()
+		{
+			return _context.Recipes
 				.Include(r => r.CreatorUser)
 				.Include(r => r.RecipeIngredients)
 				.ThenInclude(ri => ri.Ingredient)
-				.ToListAsync();
+				.Include(r => r.RecipeIngredients)
+				.ThenInclude(ri => ri.MeasureUnit);
+		}
+
+        public async Task<List<ViewModelRecipe>> GetAllItemAsync()
+        {
+
+			List<Recipe> recipes = await GetRecipesBaseQuery().ToListAsync();
             List<ViewModelRecipe> views = new List<ViewModelRecipe>();
             foreach(Recipe r in recipes)
             {
@@ -62,11 +145,8 @@ namespace TofuWarrior.BusinessLogic.Repositories
 
         public async Task<ViewModelRecipe> GetItemsByIdAsync(int id)
         {
-            Recipe result = await _context.Recipes
-				.Include(r => r.CreatorUser)
-				.Include(r => r.RecipeIngredients)
-				.ThenInclude(ri => ri.Ingredient)
-				.FirstOrDefaultAsync(recipe => recipe.RecipeId == id) ;
+            Recipe result = await GetRecipesBaseQuery()
+				.FirstOrDefaultAsync(recipe => recipe.RecipeId == id);
             ViewModelRecipe views = Mapper.ConvertToModel(result);
             return views;
         }

--- a/TheTofuWarriors/TofuWarrior.Model/ViewModels/ViewModelIngredient.cs
+++ b/TheTofuWarriors/TofuWarrior.Model/ViewModels/ViewModelIngredient.cs
@@ -4,8 +4,8 @@ namespace TheTofuWarrior.Model.ViewModels
   public class ViewModelIngredient
   {
     public int IngredientId { get; set; }
-    public string Name { get; set; }
-    public string Description { get; set; }
+    public string IngredientName { get; set; }
+    public string IngredientDescription { get; set; }
 
 
 

--- a/TheTofuWarriors/TofuWarrior.Model/ViewModels/ViewModelRecipe.cs
+++ b/TheTofuWarriors/TofuWarrior.Model/ViewModels/ViewModelRecipe.cs
@@ -4,22 +4,23 @@ using TofuWarrior.Model.ViewModels;
 
 namespace TheTofuWarrior.Model.ViewModels
 {
-  public class ViewModelRecipe
-  {
-    public int RecipeId { get; set; }
-    public int CreatorUserId { get; set; }
-    public string Name { get; set; }
-    public string Instructions { get; set; }
-    public DateTime? CreationTime { get; set; }
-    public bool IsExternal { get; set; }
-    public string ImageUrl { get; set; }
+	public class ViewModelRecipe
+	{
+		public int RecipeId { get; set; }
+		public int CreatorUserId { get; set; }
+		public ViewModelUser Creator { get; set; }
+		public string Name { get; set; }
+		public string Instructions { get; set; }
+		public DateTime? CreationTime { get; set; }
+		public bool IsExternal { get; set; }
+		public string ImageUrl { get; set; }
 
-	public string ApiKey { get; set; }
-
-
-    public List<ViewModelTag> Tags { get; set; }
-    public List<ViewModelRecipeIngredient> Ingredients { get; set; }
+		public string ApiKey { get; set; }
 
 
-  }
+		public List<ViewModelTag> Tags { get; set; }
+		public List<ViewModelRecipeIngredient> Ingredients { get; set; }
+
+
+	}
 }

--- a/TheTofuWarriors/TofuWarrior.Model/ViewModels/ViewModelRecipeIngredient.cs
+++ b/TheTofuWarriors/TofuWarrior.Model/ViewModels/ViewModelRecipeIngredient.cs
@@ -17,8 +17,11 @@ namespace TofuWarrior.Model.ViewModels
 		/************************* "Extension" properties for returning extra data from controllers **************************/
 		public string IngredientName { get; set; }
 		public string IngredientDescription { get; set; }
+		public ViewModelMeasurement MeasureUnit { get; set; }
+		/*
 		public string MeasureUnit { get; set; }
 		public string MeasureDescription { get; set; }
+		*/
 
     }
 }

--- a/TheTofuWarriors/TofuWarrior/Controllers/IngredientsController.cs
+++ b/TheTofuWarriors/TofuWarrior/Controllers/IngredientsController.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using TheTofuWarrior.Model.ViewModels;
+using TofuWarrior.Model.ViewModels;
+using TofuWarrior.BusinessLogic.Interfaces;
+
+namespace TofuWarrior.Controllers
+{
+	[Route("[controller]")]
+	[ApiController]
+	public class IngredientsController : ControllerBase
+	{
+		private IIngredientRepository _ingredients;
+		public IngredientsController(IIngredientRepository ingredients)
+		{
+			_ingredients = ingredients;
+		}
+
+		[HttpGet]
+		public async Task<List<ViewModelIngredient>> GetIngredients()
+		{
+			return await _ingredients.GetAllIngredients();
+		}
+	}
+}

--- a/TheTofuWarriors/TofuWarrior/Controllers/MeasureUnitsController.cs
+++ b/TheTofuWarriors/TofuWarrior/Controllers/MeasureUnitsController.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using TofuWarrior.BusinessLogic.Interfaces;
+using TofuWarrior.Model.ViewModels;
+
+namespace TofuWarrior.Controllers
+{
+	[Route("[controller]")]
+	[ApiController]
+	public class MeasureUnitsController : ControllerBase
+	{
+		private IMeasurementRepository _measures;
+		public MeasureUnitsController(IMeasurementRepository measures)
+		{
+			_measures = measures;
+		}
+
+		[HttpGet]
+		public async Task<List<ViewModelMeasurement>> getMeasures()
+		{
+			return await _measures.GetAllMeasurements();
+		}
+	}
+}

--- a/TheTofuWarriors/TofuWarrior/Controllers/RecipeController.cs
+++ b/TheTofuWarriors/TofuWarrior/Controllers/RecipeController.cs
@@ -17,11 +17,35 @@ namespace TofuWarrior.Controllers
         {
             _recipe = recipe;
         }
+
+
+		/// <summary>
+		/// Add a recipe to database (only affects Recipe table)
+		/// </summary>
+		/// <param name="recipe"></param>
+		/// <returns></returns>
         [HttpPost("AddRecipe")]
         public async Task AddRecipe(ViewModelRecipe recipe)
         {
             await _recipe.CreateItemAsync(recipe);
         }
+
+		public class UserRecipeData
+		{
+			public ViewModelRecipe recipe { get; set; }
+			public ViewModelUser user { get; set; }
+		}
+
+		/// <summary>
+		/// Add/update a recipe in the database (including all accompanying data)
+		/// </summary>
+		/// <returns></returns>
+		[HttpPost("SaveUserRecipe")]
+		public async Task<ViewModelRecipe> AddUserRecipe(UserRecipeData data)
+		{
+			return await _recipe.SaveUserRecipe(data.recipe, data.user);
+		}
+
         [HttpGet("GetAllRecipes")]
         public async Task<List<ViewModelRecipe>> GetAllRecipes()
         {

--- a/tofu-warriors-ui/src/app/app-routing/app-routing.module.ts
+++ b/tofu-warriors-ui/src/app/app-routing/app-routing.module.ts
@@ -1,7 +1,11 @@
 import { NgModule } from '@angular/core';
-import { RouterModule,Routes } from '@angular/router';
+import { RouterModule, Routes } from '@angular/router';
 import { LoginComponent } from '../login/login.component';
+import { RecipeBasePageComponent } from '../recipe-base-page/recipe-base-page.component';
+import { RecipeCreatePageComponent } from '../recipe-create-page/recipe-create-page.component';
+import { RecipeEditPageComponent } from '../recipe-edit-page/recipe-edit-page.component';
 import { RecipeSearchPageComponent } from '../recipe-search-page/recipe-search-page.component';
+import { RecipeViewPageComponent } from '../recipe-view-page/recipe-view-page.component';
 import { RecipesListComponent } from '../recipes-list/recipes-list.component';
 import { SignupComponent } from '../signup/signup.component';
 import { UserHomePageComponent } from '../user-home-page/user-home-page.component';
@@ -15,6 +19,14 @@ const routes: Routes = [
   { path: 'recipeSearch', component: RecipeSearchPageComponent },
   { path: 'user/:userId/profile', component: UserProfilePageComponent },
   { path: 'recipies', component: RecipesListComponent },
+  {
+    path: 'recipies/:recipeId', component: RecipeBasePageComponent,
+    children: [
+      { path: 'view', component: RecipeViewPageComponent },
+      { path: 'edit', component: RecipeEditPageComponent },
+      { path: 'clone', component: RecipeCreatePageComponent }
+    ]
+  }
 ];
 
 @NgModule({

--- a/tofu-warriors-ui/src/app/app-routing/app-routing.module.ts
+++ b/tofu-warriors-ui/src/app/app-routing/app-routing.module.ts
@@ -19,6 +19,7 @@ const routes: Routes = [
   { path: 'recipeSearch', component: RecipeSearchPageComponent },
   { path: 'user/:userId/profile', component: UserProfilePageComponent },
   { path: 'recipies', component: RecipesListComponent },
+  { path: 'recipies/create', component: RecipeCreatePageComponent },
   {
     path: 'recipies/:recipeId', component: RecipeBasePageComponent,
     children: [

--- a/tofu-warriors-ui/src/app/app.module.ts
+++ b/tofu-warriors-ui/src/app/app.module.ts
@@ -21,6 +21,7 @@ import { RecipeEditPageComponent } from './recipe-edit-page/recipe-edit-page.com
 import { RecipeCreatePageComponent } from './recipe-create-page/recipe-create-page.component';
 import { RecipeBasePageComponent } from './recipe-base-page/recipe-base-page.component';
 import { RecipeEditComponent } from './recipe-edit/recipe-edit.component';
+import { IngredientPickerComponent } from './ingredient-picker/ingredient-picker.component';
 
 @NgModule({
   declarations: [
@@ -39,7 +40,8 @@ import { RecipeEditComponent } from './recipe-edit/recipe-edit.component';
     RecipeEditPageComponent,
     RecipeCreatePageComponent,
     RecipeBasePageComponent,
-    RecipeEditComponent
+    RecipeEditComponent,
+    IngredientPickerComponent
   ],
   imports: [
     BrowserModule,

--- a/tofu-warriors-ui/src/app/app.module.ts
+++ b/tofu-warriors-ui/src/app/app.module.ts
@@ -20,6 +20,7 @@ import { RecipeViewPageComponent } from './recipe-view-page/recipe-view-page.com
 import { RecipeEditPageComponent } from './recipe-edit-page/recipe-edit-page.component';
 import { RecipeCreatePageComponent } from './recipe-create-page/recipe-create-page.component';
 import { RecipeBasePageComponent } from './recipe-base-page/recipe-base-page.component';
+import { RecipeEditComponent } from './recipe-edit/recipe-edit.component';
 
 @NgModule({
   declarations: [
@@ -37,7 +38,8 @@ import { RecipeBasePageComponent } from './recipe-base-page/recipe-base-page.com
     RecipeViewPageComponent,
     RecipeEditPageComponent,
     RecipeCreatePageComponent,
-    RecipeBasePageComponent
+    RecipeBasePageComponent,
+    RecipeEditComponent
   ],
   imports: [
     BrowserModule,

--- a/tofu-warriors-ui/src/app/app.module.ts
+++ b/tofu-warriors-ui/src/app/app.module.ts
@@ -16,6 +16,10 @@ import { RecipeDisplayComponent } from './recipe-display/recipe-display.componen
 import { RecipesListComponent } from './recipes-list/recipes-list.component';
 
 import { RecipeSearchTagPickerComponent } from './recipe-search-tag-picker/recipe-search-tag-picker.component';
+import { RecipeViewPageComponent } from './recipe-view-page/recipe-view-page.component';
+import { RecipeEditPageComponent } from './recipe-edit-page/recipe-edit-page.component';
+import { RecipeCreatePageComponent } from './recipe-create-page/recipe-create-page.component';
+import { RecipeBasePageComponent } from './recipe-base-page/recipe-base-page.component';
 
 @NgModule({
   declarations: [
@@ -29,7 +33,11 @@ import { RecipeSearchTagPickerComponent } from './recipe-search-tag-picker/recip
     UserProfilePageComponent,
     RecipeDisplayComponent,
     RecipesListComponent,
-    RecipeSearchTagPickerComponent
+    RecipeSearchTagPickerComponent,
+    RecipeViewPageComponent,
+    RecipeEditPageComponent,
+    RecipeCreatePageComponent,
+    RecipeBasePageComponent
   ],
   imports: [
     BrowserModule,

--- a/tofu-warriors-ui/src/app/ingredient-picker/ingredient-picker.component.html
+++ b/tofu-warriors-ui/src/app/ingredient-picker/ingredient-picker.component.html
@@ -3,7 +3,7 @@
   <div>
     <label for="ingredient_picker">Ingredient </label>
     <select id="ingredient_picker" name="ingredientId" [(ngModel)]="data.ingredientId">
-      <option *ngFor="let ingredient of ingredients" [value]="ingredient.ingredientId">{{ingredient.name}}</option>
+      <option *ngFor="let ingredient of ingredients" [value]="ingredient.ingredientId">{{ingredient.ingredientName}}</option>
     </select>
   </div>
   <div>
@@ -12,9 +12,12 @@
   </div>
   <div>
     <label for="ingredient_measure">Measurement unit</label>
-    <select id="ingredient_measure" name="measureId" [(ngModel)]="data.measureId">
+    <select id="ingredient_measure" name="measureId" [(ngModel)]="data.measureUnitId">
       <option *ngFor="let measure of measures" [value]="measure.measureUnitId">{{measure.description}}</option>
     </select>
   </div>
-  <button (click)="addIngredient()">Add ingredient</button>
+  <div class="ingredient-picker-actions">
+    <button (click)="addIngredient()">Add</button>
+    <button (click)="closePicker()">Cancel</button>
+  </div>
 </div>

--- a/tofu-warriors-ui/src/app/ingredient-picker/ingredient-picker.component.html
+++ b/tofu-warriors-ui/src/app/ingredient-picker/ingredient-picker.component.html
@@ -1,0 +1,20 @@
+
+<div class="ingredient-picker">
+  <div>
+    <label for="ingredient_picker">Ingredient </label>
+    <select id="ingredient_picker" name="ingredientId" [(ngModel)]="data.ingredientId">
+      <option *ngFor="let ingredient of ingredients" [value]="ingredient.ingredientId">{{ingredient.name}}</option>
+    </select>
+  </div>
+  <div>
+    <label for="ingredient_quantity">Quantity </label>
+    <input name="quantity" id="ingredient_quantity" type="number" [(ngModel)]="data.quantity"/>
+  </div>
+  <div>
+    <label for="ingredient_measure">Measurement unit</label>
+    <select id="ingredient_measure" name="measureId" [(ngModel)]="data.measureId">
+      <option *ngFor="let measure of measures" [value]="measure.measureUnitId">{{measure.description}}</option>
+    </select>
+  </div>
+  <button (click)="addIngredient()">Add ingredient</button>
+</div>

--- a/tofu-warriors-ui/src/app/ingredient-picker/ingredient-picker.component.spec.ts
+++ b/tofu-warriors-ui/src/app/ingredient-picker/ingredient-picker.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { IngredientPickerComponent } from './ingredient-picker.component';
+
+describe('IngredientPickerComponent', () => {
+  let component: IngredientPickerComponent;
+  let fixture: ComponentFixture<IngredientPickerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ IngredientPickerComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(IngredientPickerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/tofu-warriors-ui/src/app/ingredient-picker/ingredient-picker.component.ts
+++ b/tofu-warriors-ui/src/app/ingredient-picker/ingredient-picker.component.ts
@@ -1,0 +1,56 @@
+import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { Ingredient, MeasureUnit } from '../ingredient';
+import { IngredientService } from '../ingredient.service';
+
+@Component({
+  selector: 'app-ingredient-picker',
+  templateUrl: './ingredient-picker.component.html',
+  styleUrls: ['./ingredient-picker.component.css']
+})
+export class IngredientPickerComponent implements OnInit {
+
+  constructor(
+    private ingredientService: IngredientService,
+  ) { }
+
+  @Output() add = new EventEmitter<Ingredient>();
+
+  ingredients: Ingredient[] = [];
+  measures: MeasureUnit[] = [];
+
+  data = {
+    quantity: 0,
+    measureId: 0,
+    ingredientId: 0
+  }
+
+  subscriptions: Subscription[] = [];
+
+  ngOnInit(): void {
+    this.subscriptions.push(this.ingredientService.getIngredients().subscribe(ingredients => {
+      this.ingredients = ingredients;
+    }));
+    this.subscriptions.push(this.ingredientService.getMeasureUnits().subscribe(measures => {
+      this.measures = measures;
+    }));
+  }
+
+  ngOnDestroy(): void {
+    for (let sub of this.subscriptions) {
+      sub.unsubscribe();
+    }
+  }
+
+  addIngredient() {
+    let id: number = this.data.ingredientId;
+    let ingredient = this.ingredients.find(i => i.ingredientId == id);
+    let measure = this.measures.find(m => m.measureUnitId == this.data.measureId);
+    if (ingredient) {
+      let data = { ...ingredient, ...this.data, measureUnit: measure || null }
+      console.log("Adding ingredient", data);
+      this.add.emit(data);
+    }
+  }
+
+}

--- a/tofu-warriors-ui/src/app/ingredient-picker/ingredient-picker.component.ts
+++ b/tofu-warriors-ui/src/app/ingredient-picker/ingredient-picker.component.ts
@@ -15,13 +15,14 @@ export class IngredientPickerComponent implements OnInit {
   ) { }
 
   @Output() add = new EventEmitter<Ingredient>();
+  @Output() close = new EventEmitter<any>();
 
   ingredients: Ingredient[] = [];
   measures: MeasureUnit[] = [];
 
   data = {
     quantity: 0,
-    measureId: 0,
+    measureUnitId: 0,
     ingredientId: 0
   }
 
@@ -45,12 +46,16 @@ export class IngredientPickerComponent implements OnInit {
   addIngredient() {
     let id: number = this.data.ingredientId;
     let ingredient = this.ingredients.find(i => i.ingredientId == id);
-    let measure = this.measures.find(m => m.measureUnitId == this.data.measureId);
+    let measure = this.measures.find(m => m.measureUnitId == this.data.measureUnitId);
     if (ingredient) {
       let data = { ...ingredient, ...this.data, measureUnit: measure || null }
       console.log("Adding ingredient", data);
       this.add.emit(data);
     }
+  }
+
+  closePicker(): void {
+    this.close.emit();
   }
 
 }

--- a/tofu-warriors-ui/src/app/ingredient.service.spec.ts
+++ b/tofu-warriors-ui/src/app/ingredient.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { IngredientService } from './ingredient.service';
+
+describe('IngredientService', () => {
+  let service: IngredientService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(IngredientService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/tofu-warriors-ui/src/app/ingredient.service.ts
+++ b/tofu-warriors-ui/src/app/ingredient.service.ts
@@ -1,0 +1,23 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { Ingredient, MeasureUnit } from './ingredient';
+import { environment } from '../environments/environment';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class IngredientService {
+
+  constructor(
+    private http: HttpClient
+  ) { }
+
+  getIngredients(): Observable<Ingredient[]> {
+    return this.http.get<Ingredient[]>(`${environment.tofuWarriorsApiUrl}/Ingredients`);
+  }
+
+  getMeasureUnits(): Observable<MeasureUnit[]> {
+    return this.http.get<MeasureUnit[]>(`${environment.tofuWarriorsApiUrl}/MeasureUnits`);
+  }
+}

--- a/tofu-warriors-ui/src/app/ingredient.ts
+++ b/tofu-warriors-ui/src/app/ingredient.ts
@@ -7,8 +7,8 @@ export interface MeasureUnit {
 
 export interface Ingredient {
   ingredientId: number;
-  name: string;
-  description: string;
+  ingredientName: string;
+  ingredientDescription: string;
   quantity: number;
   measureUnitId: number;
   measureUnit: MeasureUnit | null;

--- a/tofu-warriors-ui/src/app/ingredient.ts
+++ b/tofu-warriors-ui/src/app/ingredient.ts
@@ -1,0 +1,29 @@
+
+export interface MeasureUnit {
+  measureUnitId: number;
+  unit: string;
+  description: string;
+}
+
+export interface Ingredient {
+  ingredientId: number;
+  name: string;
+  description: string;
+  quantity: number;
+  measureUnitId: number;
+  measureUnit: MeasureUnit | null;
+
+  /*
+  public int RecipeIngredientId { get; set; }
+        public int RecipeId { get; set; }
+        public int IngredientId { get; set; }
+        public int Quantity { get; set; }
+        public int MeasureUnitId { get; set; }
+
+		/************************* "Extension" properties for returning extra data from controllers ************************** /
+		public string IngredientName { get; set; }
+		public string IngredientDescription { get; set; }
+		public string MeasureUnit { get; set; }
+		public string MeasureDescription { get; set; }
+*/
+}

--- a/tofu-warriors-ui/src/app/recipe-base-page/recipe-base-page.component.html
+++ b/tofu-warriors-ui/src/app/recipe-base-page/recipe-base-page.component.html
@@ -1,0 +1,2 @@
+
+<router-outlet></router-outlet>

--- a/tofu-warriors-ui/src/app/recipe-base-page/recipe-base-page.component.spec.ts
+++ b/tofu-warriors-ui/src/app/recipe-base-page/recipe-base-page.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RecipeBasePageComponent } from './recipe-base-page.component';
+
+describe('RecipeBasePageComponent', () => {
+  let component: RecipeBasePageComponent;
+  let fixture: ComponentFixture<RecipeBasePageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ RecipeBasePageComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RecipeBasePageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/tofu-warriors-ui/src/app/recipe-base-page/recipe-base-page.component.ts
+++ b/tofu-warriors-ui/src/app/recipe-base-page/recipe-base-page.component.ts
@@ -1,0 +1,56 @@
+import { Location } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { Subscription } from 'rxjs';
+import { Recipe } from '../recipe';
+import { RecipePageDataService } from '../recipe-page-data.service';
+import { RecipeService } from '../recipe.service';
+import { User } from '../user';
+import { UsersService } from '../users.service';
+
+@Component({
+  selector: 'app-recipe-base-page',
+  templateUrl: './recipe-base-page.component.html',
+  styleUrls: ['./recipe-base-page.component.css']
+})
+export class RecipeBasePageComponent implements OnInit {
+
+  constructor(
+    private route: ActivatedRoute,
+    private recipePageData: RecipePageDataService,
+    private usersService: UsersService,
+    private location: Location
+  ) { }
+
+  recipe: Recipe | null = null;
+  currentUser: User | null = null;
+  recipeId: number = 0;
+  currentView: string = "";
+
+  private recipeSubscription: Subscription | null = null;
+
+  ngOnInit(): void {
+    let childRoute = this.route.firstChild;
+    if (!childRoute) {
+      this.location.go("view");
+    }
+    this.recipeSubscription = this.recipePageData.subscribeToRecipe((recipe) => {
+      this.recipe = recipe;
+      this.currentUser = this.usersService.getCurrentUser();
+    });
+
+    this.route.params.subscribe(params => {
+      this.recipeId = params["recipeId"];
+      if (!this.recipeId) {
+        throw new Error("Valid RecipeId not provided");
+      }
+      this.recipePageData.setCurrentRecipe(this.recipeId);
+    })
+  }
+
+  ngOnDestroy() {
+    this.recipeSubscription?.unsubscribe();
+    this.recipePageData.clear();
+  }
+
+}

--- a/tofu-warriors-ui/src/app/recipe-base-page/recipe-base-page.component.ts
+++ b/tofu-warriors-ui/src/app/recipe-base-page/recipe-base-page.component.ts
@@ -1,6 +1,6 @@
 import { Location } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { Recipe } from '../recipe';
 import { RecipePageDataService } from '../recipe-page-data.service';
@@ -20,7 +20,8 @@ export class RecipeBasePageComponent implements OnInit {
     private recipePageData: RecipePageDataService,
     private usersService: UsersService,
     private location: Location
-  ) { }
+  ) {
+  }
 
   recipe: Recipe | null = null;
   currentUser: User | null = null;

--- a/tofu-warriors-ui/src/app/recipe-create-page/recipe-create-page.component.html
+++ b/tofu-warriors-ui/src/app/recipe-create-page/recipe-create-page.component.html
@@ -1,0 +1,1 @@
+<p>recipe-create-page works!</p>

--- a/tofu-warriors-ui/src/app/recipe-create-page/recipe-create-page.component.html
+++ b/tofu-warriors-ui/src/app/recipe-create-page/recipe-create-page.component.html
@@ -1,4 +1,4 @@
 
 <h2>Create Recipe</h2>
 
-<app-recipe-display [recipe]="recipe"></app-recipe-display>
+<app-recipe-edit [recipe]="recipe"></app-recipe-edit>

--- a/tofu-warriors-ui/src/app/recipe-create-page/recipe-create-page.component.html
+++ b/tofu-warriors-ui/src/app/recipe-create-page/recipe-create-page.component.html
@@ -1,1 +1,4 @@
-<p>recipe-create-page works!</p>
+
+<h2>Create Recipe</h2>
+
+<app-recipe-display [recipe]="recipe"></app-recipe-display>

--- a/tofu-warriors-ui/src/app/recipe-create-page/recipe-create-page.component.html
+++ b/tofu-warriors-ui/src/app/recipe-create-page/recipe-create-page.component.html
@@ -1,4 +1,9 @@
 
 <h2>Create Recipe</h2>
 
-<app-recipe-edit [recipe]="recipe"></app-recipe-edit>
+<div *ngIf="currentUser">
+  <app-recipe-edit [recipe]="recipe" (save)="saveRecipe($event)"></app-recipe-edit>
+</div>
+<div *ngIf="!currentUser">
+  <p>You must be logged in to create a recipe</p>
+</div>

--- a/tofu-warriors-ui/src/app/recipe-create-page/recipe-create-page.component.spec.ts
+++ b/tofu-warriors-ui/src/app/recipe-create-page/recipe-create-page.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RecipeCreatePageComponent } from './recipe-create-page.component';
+
+describe('RecipeCreatePageComponent', () => {
+  let component: RecipeCreatePageComponent;
+  let fixture: ComponentFixture<RecipeCreatePageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ RecipeCreatePageComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RecipeCreatePageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/tofu-warriors-ui/src/app/recipe-create-page/recipe-create-page.component.ts
+++ b/tofu-warriors-ui/src/app/recipe-create-page/recipe-create-page.component.ts
@@ -17,7 +17,8 @@ export class RecipeCreatePageComponent implements OnInit {
   constructor(
     private location: Location,
     private users: UsersService,
-    private recipeService: RecipeService
+    private recipeService: RecipeService,
+    private router: Router
   ) {
     this.currentUser = this.users.getCurrentUser();
     this.recipe = {
@@ -82,7 +83,9 @@ export class RecipeCreatePageComponent implements OnInit {
     this.recipe.recipeId = 0;
     this.subscriptions.push(this.recipeService.saveUserRecipe(this.recipe, this.currentUser).subscribe(recipe => {
       this.recipe = recipe;
-      this.location.go("../view");
+      let dest = `/recipies/${recipe.recipeId}/view`;
+      this.router.navigate([dest], { replaceUrl: true });
+      //this.location.replaceState(dest);
     }));
   }
 }

--- a/tofu-warriors-ui/src/app/recipe-create-page/recipe-create-page.component.ts
+++ b/tofu-warriors-ui/src/app/recipe-create-page/recipe-create-page.component.ts
@@ -2,6 +2,8 @@ import { Location } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { Recipe } from '../recipe';
+import { User } from '../user';
+import { UsersService } from '../users.service';
 
 @Component({
   selector: 'app-recipe-create-page',
@@ -11,15 +13,48 @@ import { Recipe } from '../recipe';
 export class RecipeCreatePageComponent implements OnInit {
 
   constructor(
-    private location: Location
-  ) { }
+    private location: Location,
+    private users: UsersService,
+  ) {
+    this.currentUser = this.users.getCurrentUser();
+    this.recipe = {
+      recipeId: 0,
+      apiKey: "",
+      creationTime: new Date(),
+      creator: this.currentUser,
+      creatorUserId: this.currentUser?.userId || 0,
+      imageUrl: "",
+      ingredients: [],
+      instructions: "",
+      isExternal: false,
+      name: "",
+      tags: []
+    }
+  }
 
   baseRecipe: Recipe | null = null;
+  currentUser: User | null;
+  recipe: Recipe;
 
   ngOnInit(): void {
+    // get baseRecipe from state location (set by page that navigated here)
     let state = this.location.getState() as { baseRecipe: Recipe };
     console.log("nav: ", state);
     this.baseRecipe = state.baseRecipe;
+    if (this.baseRecipe) this.populateRecipeFromBase(this.baseRecipe);
   }
 
+  populateRecipeFromBase(base: Recipe) {
+    let valuesToCopy = {
+      recipeId: base.recipeId,
+      apiKey: base.apiKey,
+      imageUrl: base.imageUrl,
+      ingredients: [ ...base.ingredients ],
+      instructions: base.instructions,
+      name: base.name,
+      tags: [...base.tags]
+    }
+    this.recipe = { ...this.recipe, ...valuesToCopy };
+    console.log("cloned recipe: ", this.recipe);
+  }
 }

--- a/tofu-warriors-ui/src/app/recipe-create-page/recipe-create-page.component.ts
+++ b/tofu-warriors-ui/src/app/recipe-create-page/recipe-create-page.component.ts
@@ -1,7 +1,9 @@
 import { Location } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
+import { Subscription } from 'rxjs';
 import { Recipe } from '../recipe';
+import { RecipeService } from '../recipe.service';
 import { User } from '../user';
 import { UsersService } from '../users.service';
 
@@ -15,6 +17,7 @@ export class RecipeCreatePageComponent implements OnInit {
   constructor(
     private location: Location,
     private users: UsersService,
+    private recipeService: RecipeService
   ) {
     this.currentUser = this.users.getCurrentUser();
     this.recipe = {
@@ -36,12 +39,18 @@ export class RecipeCreatePageComponent implements OnInit {
   currentUser: User | null;
   recipe: Recipe;
 
+  subscriptions: Subscription[] = [];
+
   ngOnInit(): void {
     // get baseRecipe from state location (set by page that navigated here)
     let state = this.location.getState() as { baseRecipe: Recipe };
     console.log("nav: ", state);
     this.baseRecipe = state.baseRecipe;
     if (this.baseRecipe) this.populateRecipeFromBase(this.baseRecipe);
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.forEach(s => s.unsubscribe());
   }
 
   populateRecipeFromBase(base: Recipe) {
@@ -58,7 +67,22 @@ export class RecipeCreatePageComponent implements OnInit {
     console.log("cloned recipe: ", this.recipe);
   }
 
-  saveRecipe(): void {
+  saveRecipe(shouldSave: boolean): void {
+    if (!shouldSave) {
+      this.location.back();
+      return;
+    }
     console.log("Saving", this.recipe);
+    if (!this.currentUser) {
+      throw new Error("Cannot save when not logged in");
+    }
+    if (!this.recipe) {
+      throw new Error("No recipe data found");
+    }
+    this.recipe.recipeId = 0;
+    this.subscriptions.push(this.recipeService.saveUserRecipe(this.recipe, this.currentUser).subscribe(recipe => {
+      this.recipe = recipe;
+      this.location.go("../view");
+    }));
   }
 }

--- a/tofu-warriors-ui/src/app/recipe-create-page/recipe-create-page.component.ts
+++ b/tofu-warriors-ui/src/app/recipe-create-page/recipe-create-page.component.ts
@@ -1,0 +1,25 @@
+import { Location } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { Recipe } from '../recipe';
+
+@Component({
+  selector: 'app-recipe-create-page',
+  templateUrl: './recipe-create-page.component.html',
+  styleUrls: ['./recipe-create-page.component.css']
+})
+export class RecipeCreatePageComponent implements OnInit {
+
+  constructor(
+    private location: Location
+  ) { }
+
+  baseRecipe: Recipe | null = null;
+
+  ngOnInit(): void {
+    let state = this.location.getState() as { baseRecipe: Recipe };
+    console.log("nav: ", state);
+    this.baseRecipe = state.baseRecipe;
+  }
+
+}

--- a/tofu-warriors-ui/src/app/recipe-create-page/recipe-create-page.component.ts
+++ b/tofu-warriors-ui/src/app/recipe-create-page/recipe-create-page.component.ts
@@ -57,4 +57,8 @@ export class RecipeCreatePageComponent implements OnInit {
     this.recipe = { ...this.recipe, ...valuesToCopy };
     console.log("cloned recipe: ", this.recipe);
   }
+
+  saveRecipe(): void {
+    console.log("Saving", this.recipe);
+  }
 }

--- a/tofu-warriors-ui/src/app/recipe-display/recipe-display.component.html
+++ b/tofu-warriors-ui/src/app/recipe-display/recipe-display.component.html
@@ -3,7 +3,7 @@
 <div *ngIf="recipe">
   <h4>{{recipe.name}}</h4>
   <!-- TODO: get user info from recipe object? -->
-  <p>Created by: {{recipe.creator.firstName}} {{recipe.creator.lastName}}</p>
+  <p>Created by: <span *ngIf="recipe.creator">{{recipe.creator.firstName}} {{recipe.creator.lastName}}</span></p>
   <p>Ingredients:</p>
   <ul>
     <li *ngFor="let ingredient of recipe.ingredients">{{ingredient.quantity}} {{ingredient.measureDescription}} {{ingredient.ingredientName}}</li>

--- a/tofu-warriors-ui/src/app/recipe-display/recipe-display.component.html
+++ b/tofu-warriors-ui/src/app/recipe-display/recipe-display.component.html
@@ -3,7 +3,7 @@
 <div *ngIf="recipe">
   <h4>{{recipe.name}}</h4>
   <!-- TODO: get user info from recipe object? -->
-  <p>Created by: </p>
+  <p>Created by: {{recipe.creator.firstName}} {{recipe.creator.lastName}}</p>
   <p>Ingredients:</p>
   <ul>
     <li *ngFor="let ingredient of recipe.ingredients">{{ingredient.quantity}} {{ingredient.measureDescription}} {{ingredient.ingredientName}}</li>

--- a/tofu-warriors-ui/src/app/recipe-display/recipe-display.component.html
+++ b/tofu-warriors-ui/src/app/recipe-display/recipe-display.component.html
@@ -6,7 +6,7 @@
   <p>Created by: <span *ngIf="recipe.creator">{{recipe.creator.firstName}} {{recipe.creator.lastName}}</span></p>
   <p>Ingredients:</p>
   <ul>
-    <li *ngFor="let ingredient of recipe.ingredients">{{ingredient.quantity}} {{ingredient.measureDescription}} {{ingredient.ingredientName}}</li>
+    <li *ngFor="let ingredient of recipe.ingredients">{{ingredient.quantity}} {{ingredient.measureUnit?.description}} {{ingredient.ingredientName}}</li>
   </ul>
   <p>Instructions:</p>
   <p>{{recipe.instructions}}</p>

--- a/tofu-warriors-ui/src/app/recipe-display/recipe-display.component.ts
+++ b/tofu-warriors-ui/src/app/recipe-display/recipe-display.component.ts
@@ -15,4 +15,8 @@ export class RecipeDisplayComponent implements OnInit {
   ngOnInit(): void {
   }
 
+  ngOnChanges(): void {
+    console.log("recipe display:", this.recipe);
+  }
+
 }

--- a/tofu-warriors-ui/src/app/recipe-edit-page/recipe-edit-page.component.html
+++ b/tofu-warriors-ui/src/app/recipe-edit-page/recipe-edit-page.component.html
@@ -1,0 +1,1 @@
+<p>recipe-edit-page works!</p>

--- a/tofu-warriors-ui/src/app/recipe-edit-page/recipe-edit-page.component.html
+++ b/tofu-warriors-ui/src/app/recipe-edit-page/recipe-edit-page.component.html
@@ -1,4 +1,4 @@
 
 <h2>Edit Recipe</h2>
 
-<app-recipe-display [recipe]="recipe"></app-recipe-display>
+<app-recipe-edit [recipe]="recipe"></app-recipe-edit>

--- a/tofu-warriors-ui/src/app/recipe-edit-page/recipe-edit-page.component.html
+++ b/tofu-warriors-ui/src/app/recipe-edit-page/recipe-edit-page.component.html
@@ -1,4 +1,9 @@
 
 <h2>Edit Recipe</h2>
 
-<app-recipe-edit [recipe]="recipe"></app-recipe-edit>
+<div *ngIf="currentUser">
+  <app-recipe-edit [recipe]="recipe" (save)="saveChanges($event)"></app-recipe-edit>
+</div>
+<div *ngIf="!currentUser">
+  <p>You must be logged in to edit a recipe</p>
+</div>

--- a/tofu-warriors-ui/src/app/recipe-edit-page/recipe-edit-page.component.html
+++ b/tofu-warriors-ui/src/app/recipe-edit-page/recipe-edit-page.component.html
@@ -1,1 +1,4 @@
-<p>recipe-edit-page works!</p>
+
+<h2>Edit Recipe</h2>
+
+<app-recipe-display [recipe]="recipe"></app-recipe-display>

--- a/tofu-warriors-ui/src/app/recipe-edit-page/recipe-edit-page.component.spec.ts
+++ b/tofu-warriors-ui/src/app/recipe-edit-page/recipe-edit-page.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RecipeEditPageComponent } from './recipe-edit-page.component';
+
+describe('RecipeEditPageComponent', () => {
+  let component: RecipeEditPageComponent;
+  let fixture: ComponentFixture<RecipeEditPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ RecipeEditPageComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RecipeEditPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/tofu-warriors-ui/src/app/recipe-edit-page/recipe-edit-page.component.ts
+++ b/tofu-warriors-ui/src/app/recipe-edit-page/recipe-edit-page.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-recipe-edit-page',
+  templateUrl: './recipe-edit-page.component.html',
+  styleUrls: ['./recipe-edit-page.component.css']
+})
+export class RecipeEditPageComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/tofu-warriors-ui/src/app/recipe-edit-page/recipe-edit-page.component.ts
+++ b/tofu-warriors-ui/src/app/recipe-edit-page/recipe-edit-page.component.ts
@@ -1,4 +1,7 @@
 import { Component, OnInit } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { Recipe } from '../recipe';
+import { RecipePageDataService } from '../recipe-page-data.service';
 
 @Component({
   selector: 'app-recipe-edit-page',
@@ -7,9 +10,22 @@ import { Component, OnInit } from '@angular/core';
 })
 export class RecipeEditPageComponent implements OnInit {
 
-  constructor() { }
+  constructor(
+    private recipePageData: RecipePageDataService
+  ) { }
+
+  recipeSubscription: Subscription | null = null;
+  recipe: Recipe | null = null;
 
   ngOnInit(): void {
+   this.recipeSubscription = this.recipePageData.subscribeToRecipe((recipe) => {
+      console.log("Recipe view page: ", recipe);
+      this.recipe = recipe;
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.recipeSubscription?.unsubscribe();
   }
 
 }

--- a/tofu-warriors-ui/src/app/recipe-edit-page/recipe-edit-page.component.ts
+++ b/tofu-warriors-ui/src/app/recipe-edit-page/recipe-edit-page.component.ts
@@ -1,5 +1,6 @@
 import { Location } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { Recipe } from '../recipe';
 import { RecipePageDataService } from '../recipe-page-data.service';
@@ -18,7 +19,8 @@ export class RecipeEditPageComponent implements OnInit {
     private recipePageData: RecipePageDataService,
     private recipeService: RecipeService,
     private users: UsersService,
-    private location: Location
+    private location: Location,
+    private router: Router
   ) { }
 
   subscriptions: Subscription[] = [];
@@ -51,7 +53,10 @@ export class RecipeEditPageComponent implements OnInit {
     }
     this.subscriptions.push(this.recipeService.saveUserRecipe(this.recipe, this.currentUser).subscribe(recipe => {
       this.recipe = recipe;
-      this.location.go("../view");
+      let dest = `/recipies/${recipe.recipeId}/view`;
+      this.router.navigate([dest]);
+      this.router.navigate([dest], { replaceUrl: true });
+      //this.location.replaceState(dest);
     }));
   }
 

--- a/tofu-warriors-ui/src/app/recipe-edit/recipe-edit.component.css
+++ b/tofu-warriors-ui/src/app/recipe-edit/recipe-edit.component.css
@@ -1,0 +1,5 @@
+
+.recipe-instructions {
+    min-width: 80%;
+    min-height: 200px;
+}

--- a/tofu-warriors-ui/src/app/recipe-edit/recipe-edit.component.html
+++ b/tofu-warriors-ui/src/app/recipe-edit/recipe-edit.component.html
@@ -1,0 +1,1 @@
+<p>recipe-edit works!</p>

--- a/tofu-warriors-ui/src/app/recipe-edit/recipe-edit.component.html
+++ b/tofu-warriors-ui/src/app/recipe-edit/recipe-edit.component.html
@@ -1,1 +1,17 @@
-<p>recipe-edit works!</p>
+
+<div *ngIf="recipe">
+  <label for="recipe_name">Name: </label>
+  <input id="recpie_name" name="recipe_name" [(ngModel)]="recipe.name" />
+  <!-- TODO: get user info from recipe object? -->
+  <p>Created by: <span *ngIf="recipe.creator">{{recipe.creator.firstName}} {{recipe.creator.lastName}}</span></p>
+  <p>Ingredients:</p>
+  <ul>
+    <li *ngFor="let ingredient of recipe.ingredients">{{ingredient.quantity}} {{ingredient.measureUnit.description}} {{ingredient.name}}
+      <button (click)="removeIngredient(ingredient)">Remove</button>
+    </li>
+  </ul>
+  <app-ingredient-picker (add)="addIngredient($event)"></app-ingredient-picker>
+  <p>Instructions:</p>
+    <textarea name="recipe-instructions" [(ngModel)]="recipe.instructions"></textarea>
+</div>
+

--- a/tofu-warriors-ui/src/app/recipe-edit/recipe-edit.component.html
+++ b/tofu-warriors-ui/src/app/recipe-edit/recipe-edit.component.html
@@ -6,12 +6,23 @@
   <p>Created by: <span *ngIf="recipe.creator">{{recipe.creator.firstName}} {{recipe.creator.lastName}}</span></p>
   <p>Ingredients:</p>
   <ul>
-    <li *ngFor="let ingredient of recipe.ingredients">{{ingredient.quantity}} {{ingredient.measureUnit.description}} {{ingredient.name}}
+    <li *ngFor="let ingredient of recipe.ingredients">
+      {{ingredient.quantity}} {{ingredient.measureUnit?.description}} {{ingredient.ingredientName}}
       <button (click)="removeIngredient(ingredient)">Remove</button>
     </li>
   </ul>
-  <app-ingredient-picker (add)="addIngredient($event)"></app-ingredient-picker>
+  <div *ngIf="showIngredientPicker">
+    <app-ingredient-picker (add)="addIngredient($event)" (close)="toggleIngredientPicker()"></app-ingredient-picker>
+  </div>
+  <div *ngIf="!showIngredientPicker">
+    <button (click)="toggleIngredientPicker()">Add Ingredient</button>
+  </div>
   <p>Instructions:</p>
-    <textarea name="recipe-instructions" [(ngModel)]="recipe.instructions"></textarea>
+  <textarea class="recipe-instructions" name="recipe-instructions" [(ngModel)]="recipe.instructions"></textarea>
+  <div class="recipe-edit-actions">
+
+    <button (click)="saveRecipe()">Save</button>
+    <button (click)="cancelEdits()">Cancel</button>
+  </div>
 </div>
 

--- a/tofu-warriors-ui/src/app/recipe-edit/recipe-edit.component.spec.ts
+++ b/tofu-warriors-ui/src/app/recipe-edit/recipe-edit.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RecipeEditComponent } from './recipe-edit.component';
+
+describe('RecipeEditComponent', () => {
+  let component: RecipeEditComponent;
+  let fixture: ComponentFixture<RecipeEditComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ RecipeEditComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RecipeEditComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/tofu-warriors-ui/src/app/recipe-edit/recipe-edit.component.ts
+++ b/tofu-warriors-ui/src/app/recipe-edit/recipe-edit.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-recipe-edit',
+  templateUrl: './recipe-edit.component.html',
+  styleUrls: ['./recipe-edit.component.css']
+})
+export class RecipeEditComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/tofu-warriors-ui/src/app/recipe-edit/recipe-edit.component.ts
+++ b/tofu-warriors-ui/src/app/recipe-edit/recipe-edit.component.ts
@@ -1,6 +1,10 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Location } from '@angular/common';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Subscription } from 'rxjs';
 import { Ingredient } from '../ingredient';
 import { Recipe } from '../recipe';
+import { RecipeService } from '../recipe.service';
+import { UsersService } from '../users.service';
 
 @Component({
   selector: 'app-recipe-edit',
@@ -10,11 +14,21 @@ import { Recipe } from '../recipe';
 export class RecipeEditComponent implements OnInit {
 
   constructor(
+    private location: Location,
+    private recipeService: RecipeService,
+    private users: UsersService
   ) { }
 
   @Input() recipe: Recipe | null = null;
+  @Output() save: EventEmitter<boolean> = new EventEmitter<boolean>();
+
+  showIngredientPicker: boolean = false;
 
   ngOnInit(): void {
+  }
+
+  toggleIngredientPicker() {
+    this.showIngredientPicker = !this.showIngredientPicker;
   }
 
   addIngredient(ingredient: Ingredient) {
@@ -48,6 +62,14 @@ export class RecipeEditComponent implements OnInit {
       return;
     }
     this.recipe.ingredients = this.recipe.ingredients.filter(i => !this.isMatch(i, ingredient));
+  }
+
+  saveRecipe(): void {
+    this.save.emit(true);
+  }
+
+  cancelEdits(): void {
+    this.save.emit(false);
   }
 
 }

--- a/tofu-warriors-ui/src/app/recipe-edit/recipe-edit.component.ts
+++ b/tofu-warriors-ui/src/app/recipe-edit/recipe-edit.component.ts
@@ -1,4 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
+import { Ingredient } from '../ingredient';
+import { Recipe } from '../recipe';
 
 @Component({
   selector: 'app-recipe-edit',
@@ -7,9 +9,45 @@ import { Component, OnInit } from '@angular/core';
 })
 export class RecipeEditComponent implements OnInit {
 
-  constructor() { }
+  constructor(
+  ) { }
+
+  @Input() recipe: Recipe | null = null;
 
   ngOnInit(): void {
+  }
+
+  addIngredient(ingredient: Ingredient) {
+    if (!this.recipe) {
+      return;
+    }
+    if (!this.recipe.ingredients) {
+      this.recipe.ingredients = [];
+    }
+    if (this.recipe.ingredients.find(i => this.isMatch(i, ingredient))) {
+      // ingredient already in list
+      return;
+    }
+    this.recipe.ingredients.push(ingredient);
+  }
+
+  isMatch(i1: Ingredient, i2: Ingredient): boolean {
+      return (
+        i1.ingredientId === i2.ingredientId
+        && i1.measureUnitId == i2.measureUnitId
+        && i1.quantity == i2.quantity
+      );
+  }
+
+  removeIngredient(ingredient: Ingredient) {
+    if (!this.recipe) {
+      return;
+    }
+    if (!this.recipe.ingredients) {
+      this.recipe.ingredients = [];
+      return;
+    }
+    this.recipe.ingredients = this.recipe.ingredients.filter(i => !this.isMatch(i, ingredient));
   }
 
 }

--- a/tofu-warriors-ui/src/app/recipe-page-data.service.spec.ts
+++ b/tofu-warriors-ui/src/app/recipe-page-data.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { RecipePageDataService } from './recipe-page-data.service';
+
+describe('RecipePageDataService', () => {
+  let service: RecipePageDataService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(RecipePageDataService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/tofu-warriors-ui/src/app/recipe-page-data.service.ts
+++ b/tofu-warriors-ui/src/app/recipe-page-data.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@angular/core';
+import { Observer, PartialObserver, Subject, Subscription } from 'rxjs';
+import { Recipe } from './recipe';
+import { RecipeService } from './recipe.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class RecipePageDataService {
+
+  constructor(
+    private recipeService: RecipeService,
+  ) {
+    this.recipeSubject = new Subject();
+  }
+
+  private recipeSubject: Subject<Recipe>;
+  private currentRecipe: Recipe | null = null;
+
+  subscribeToRecipe(subscriber: (value: Recipe) => void): Subscription {
+    let sub: Subscription = this.recipeSubject.subscribe(subscriber);
+    if (this.currentRecipe) subscriber(this.currentRecipe);
+    return sub;
+  }
+
+  setCurrentRecipe(recipeId: number) {
+    this.recipeService.getRecipeById(recipeId).subscribe(recipe => {
+      this.currentRecipe = recipe;
+      this.recipeSubject.next(recipe);
+    });
+  }
+
+  clear() {
+    this.currentRecipe = null;
+  }
+
+}

--- a/tofu-warriors-ui/src/app/recipe-view-page/recipe-view-page.component.html
+++ b/tofu-warriors-ui/src/app/recipe-view-page/recipe-view-page.component.html
@@ -1,0 +1,8 @@
+
+<h2>View Recipe</h2>
+<div>
+  <button (click)="goBack()">Back</button>
+  <button *ngIf="recipeEditable" (click)="editRecipe()">Edit</button>
+  <button *ngIf="!recipeEditable" (click)="cloneRecipe()">Add To My Recipes</button>
+  <app-recipe-display [recipe]="recipe"></app-recipe-display>
+</div>

--- a/tofu-warriors-ui/src/app/recipe-view-page/recipe-view-page.component.spec.ts
+++ b/tofu-warriors-ui/src/app/recipe-view-page/recipe-view-page.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RecipeViewPageComponent } from './recipe-view-page.component';
+
+describe('RecipeViewPageComponent', () => {
+  let component: RecipeViewPageComponent;
+  let fixture: ComponentFixture<RecipeViewPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ RecipeViewPageComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RecipeViewPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/tofu-warriors-ui/src/app/recipe-view-page/recipe-view-page.component.ts
+++ b/tofu-warriors-ui/src/app/recipe-view-page/recipe-view-page.component.ts
@@ -1,0 +1,74 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Location } from "@angular/common";
+import { Recipe } from '../recipe';
+import { RecipeService } from '../recipe.service';
+import { User } from '../user';
+import { UsersService } from '../users.service';
+import { RecipePageDataService } from '../recipe-page-data.service';
+import { Subscription } from 'rxjs';
+
+@Component({
+  selector: 'app-recipe-view-page',
+  templateUrl: './recipe-view-page.component.html',
+  styleUrls: ['./recipe-view-page.component.css']
+})
+export class RecipeViewPageComponent implements OnInit {
+
+  constructor(
+    private route: ActivatedRoute,
+    private usersService: UsersService,
+    private location: Location,
+    private recipePageData: RecipePageDataService,
+    private router: Router
+  ) { }
+
+  recipe: Recipe | null = null;
+  currentUser: User | null = null;
+
+  recipeEditable: boolean = false;
+
+  private recipeSubscription: Subscription | null = null;
+
+  ngOnInit(): void {
+   this.recipeSubscription = this.recipePageData.subscribeToRecipe((recipe) => {
+      console.log("Recipe view page: ", recipe);
+      this.recipe = recipe;
+    });
+   }
+
+  ngOnDestroy(): void {
+    this.recipeSubscription?.unsubscribe();
+  }
+
+  ngOnChanges(): void {
+    this.currentUser = this.usersService.getCurrentUser();
+    if (!this.currentUser) {
+      this.recipeEditable = false;
+    } else if (!this.recipe) {
+      this.recipeEditable = false;
+    } else if (this.currentUser.userId == null || this.currentUser.userId !== this.recipe.creatorUserId) {
+      this.recipeEditable = false;
+    } else {
+      this.recipeEditable = true;
+    }
+  }
+
+  editRecipe(): void {
+    console.log("Edit recipe");
+    this.router.navigate(["../edit"], { relativeTo: this.route });
+  }
+
+  goBack(): void {
+    this.location.back();
+  }
+
+  cloneRecipe(): void {
+    console.log("Clone recipe");
+    this.router.navigate(["../clone"], {
+      relativeTo: this.route,
+      state: { baseRecipe: this.recipe }
+    });
+  }
+
+}

--- a/tofu-warriors-ui/src/app/recipe-view-page/recipe-view-page.component.ts
+++ b/tofu-warriors-ui/src/app/recipe-view-page/recipe-view-page.component.ts
@@ -34,6 +34,7 @@ export class RecipeViewPageComponent implements OnInit {
    this.recipeSubscription = this.recipePageData.subscribeToRecipe((recipe) => {
       console.log("Recipe view page: ", recipe);
       this.recipe = recipe;
+      this.updateExtraInfo();
     });
    }
 
@@ -41,17 +42,25 @@ export class RecipeViewPageComponent implements OnInit {
     this.recipeSubscription?.unsubscribe();
   }
 
-  ngOnChanges(): void {
+  updateExtraInfo(): void {
     this.currentUser = this.usersService.getCurrentUser();
     if (!this.currentUser) {
+      console.log("view updateExtraInfo 1");
       this.recipeEditable = false;
     } else if (!this.recipe) {
+      console.log("view updateExtraInfo 2");
       this.recipeEditable = false;
     } else if (this.currentUser.userId == null || this.currentUser.userId !== this.recipe.creatorUserId) {
+      console.log("view updateExtraInfo 3");
       this.recipeEditable = false;
     } else {
+      console.log("view updateExtraInfo 4");
       this.recipeEditable = true;
     }
+    console.log("view updateExtraInfo 5");
+  }
+
+  ngOnChanges(): void {
   }
 
   editRecipe(): void {

--- a/tofu-warriors-ui/src/app/recipe.service.ts
+++ b/tofu-warriors-ui/src/app/recipe.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from '../environments/environment';
 import { Recipe } from './recipe';
+import { User } from './user';
 import { UsersService } from './users.service';
 
 @Injectable({
@@ -38,5 +39,10 @@ export class RecipeService {
 
   searchRecipes(terms: string[], tags: any[]): Observable<Recipe[]> {
     return this.httpClient.post<Recipe[]>(`${this.apiUrl}/Recipe/Search`, { terms, tags }, { headers: this.jsonHeader });
+  }
+
+  saveUserRecipe(recipe: Recipe, user: User) {
+
+    return this.httpClient.post<Recipe>(`${this.apiUrl}/Recipe/SaveUserRecipe`, { recipe, user }, { headers: this.jsonHeader });
   }
 }

--- a/tofu-warriors-ui/src/app/recipe.service.ts
+++ b/tofu-warriors-ui/src/app/recipe.service.ts
@@ -23,6 +23,10 @@ export class RecipeService {
     return this.httpClient.get<Recipe[]>(`${this.apiUrl}/User/${userId}/recipes`);
   }
 
+  getRecipeById(recipeId: number): Observable<Recipe> {
+    return this.httpClient.get<Recipe>(`${this.apiUrl}/Recipe/GetRecipeById?id=${recipeId}`);
+  }
+
   //get the recipe list
   getRecipeList():Observable<Recipe[]>{
     return this.httpClient.get<Recipe[]>(`${this.apiUrl}/Recipe/GetAllRecipes`);

--- a/tofu-warriors-ui/src/app/recipe.ts
+++ b/tofu-warriors-ui/src/app/recipe.ts
@@ -3,7 +3,7 @@ import { User } from './user';
 export interface Recipe {
   recipeId: number;
   creatorUserId: number;
-  creator: User;
+  creator: User | null;
   name: string;
   instructions: string;
   creationTime: Date;

--- a/tofu-warriors-ui/src/app/recipe.ts
+++ b/tofu-warriors-ui/src/app/recipe.ts
@@ -3,7 +3,7 @@ import { User } from './user';
 export interface Recipe {
   recipeId: number;
   creatorUserId: number;
-  //creator: User;
+  creator: User;
   name: string;
   instructions: string;
   creationTime: Date;

--- a/tofu-warriors-ui/src/app/recipe.ts
+++ b/tofu-warriors-ui/src/app/recipe.ts
@@ -1,3 +1,4 @@
+import { Ingredient } from './ingredient';
 import { User } from './user';
 
 export interface Recipe {
@@ -10,6 +11,6 @@ export interface Recipe {
   isExternal: boolean;
   imageUrl: string;
   apiKey: string;
-  ingredients: any[];
+  ingredients: Ingredient[];
   tags: any[];
 }

--- a/tofu-warriors-ui/src/app/recipes-list/recipes-list.component.html
+++ b/tofu-warriors-ui/src/app/recipes-list/recipes-list.component.html
@@ -1,7 +1,7 @@
 <div >
 	<h1>Recipes Lists</h1>
 	<ul class="recipes"></ul>
-	<li *ngFor ="let recipe of recipies"  (click)="onSelect(recipe)">
+	<li *ngFor ="let recipe of recipies" routerLink="/recipies/{{recipe.recipeId}}/view">
 		<span>{{recipe.name}} </span>
 		
 	</li>

--- a/tofu-warriors-ui/src/app/recipes-list/recipes-list.component.html
+++ b/tofu-warriors-ui/src/app/recipes-list/recipes-list.component.html
@@ -1,14 +1,16 @@
-<div >
-	<h1>Recipes Lists</h1>
-	<ul class="recipes"></ul>
-	<li *ngFor ="let recipe of recipies" routerLink="/recipies/{{recipe.recipeId}}/view">
-		<span>{{recipe.name}} </span>
-		
-	</li>
-	
+<div>
+  <h1>Recipes Lists</h1>
+  <button routerLink="/recipies/create">New Recipe</button>
+  <ul class="recipes">
+    <li *ngFor="let recipe of recipies" routerLink="/recipies/{{recipe.recipeId}}/view">
+      <span>{{recipe.name}} </span>
+
+    </li>
+  </ul>
+
 </div>
 
 <div *ngIf="selectedRecipe">
-	<app-recipe-display [recipe]="selectedRecipe" ></app-recipe-display>
+  <app-recipe-display [recipe]="selectedRecipe"></app-recipe-display>
 </div>
 

--- a/tofu-warriors-ui/src/app/user-display/user-display.component.ts
+++ b/tofu-warriors-ui/src/app/user-display/user-display.component.ts
@@ -21,7 +21,7 @@ export class UserDisplayComponent implements OnInit {
   loadUsers(): void {
     console.log("loading users 2");
     this.users.getUsers().subscribe(data => {
-      console.log(`Got user data: ${data}`)
+      console.log(`Got user data: `, data)
       this.usersList = data
     });
   }


### PR DESCRIPTION
This commit will set up pages to let the user view, edit, or clone an exiting recipe, and create a new recipe.
This includes functionality to navigate between the pages and also updates to the api controller/repo functionalities as needed.

Customizing recipe tags is not currently supported.